### PR TITLE
Variable halo and padding extents

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Written in modern Fortran, with GPU support through OpenACC kernels and MPI.
     - Contains a core file (`diezdecomp_core.f90`), and two API versions:
         - `diezdecomp_api_cans.f90` for compatibility with the CaNS project (https://github.com/CaNS-World/CaNS)
         - `diezdecomp_api_generic.f90` for general-purpose operations, compatible with any project.
- 
+
 3) Installation:
     - Please copy the source files (`diezdecomp_core.f90` and the desired API version `diezdecomp_api_*.f90`) to your work directory, and compile them together with any other Fortran code.
     - Re-run the test suite (`./tests`) and examples (`./examples`) in the target platform to ensure full compatibility.

--- a/examples/halo/example_1/example_1_halo.f90
+++ b/examples/halo/example_1/example_1_halo.f90
@@ -114,12 +114,12 @@ program main
     periodic_xyz(ii)  =  (read_int0 == 1)
   end block
   ! -------------------- End: read data --------------------
-  
+
   ! local padding (offset6)
   offset6  =   all_offset6(irank,:,:)
 
   ! allocate 3D arrays
-  block 
+  block
     integer :: sx_0, sx_1, sx_2
     ! shape local array [sx_0, sx_1, sx_2]
     sx_0 = all_n3(irank,0) + sum(offset6(0,:))
@@ -132,9 +132,9 @@ program main
   end block
 
   ! ------------------------- Begin: Verification Array Setup -------------------------
-  block 
+  block
     integer :: lo_loc(0:2), lo_xyz(0:2), n_global(0:2), inv_order_halo(0:2)
-    
+
     ! reversed order (useful to have)
     block
       integer :: i,j
@@ -180,7 +180,7 @@ program main
     lo_loc(0) = lo_xyz(order_halo(0))
     lo_loc(1) = lo_xyz(order_halo(1))
     lo_loc(2) = lo_xyz(order_halo(2))
-    
+
     ! define reference values (A_ref)
     block
       integer :: i,j,k, ijk_loc(0:2), ijk_0(0:2), axis, jj, kk, sz_jj, sz_kk
@@ -209,7 +209,7 @@ program main
             valid    =  (ijk_0(ii)>=0).and.(ijk_0(ii)<n_global(ii))
             valid    =  valid.and.(ijk_0(jj)>=lo_xyz(jj)).and.(ijk_0(jj)<sz_jj)
             valid    =  valid.and.(ijk_0(kk)>=lo_xyz(kk)).and.(ijk_0(kk)<sz_kk)
-            if (valid) then 
+            if (valid) then
                A_ref(i+offset6(0,0), &
                       j+offset6(1,0), &
                       k+offset6(2,0))  =  ijk_0(0)*n_global(1)*n_global(2) + ijk_0(1)*n_global(2) + ijk_0(2) + 1
@@ -222,8 +222,8 @@ program main
   ! ------------------------- End: Verification Array Setup -------------------------
 
   ! Copy inner part of verification array (without halo cells or offset6) to "A"
-  block 
-    integer :: i0,i1,j0,j1,k0,k1 
+  block
+    integer :: i0,i1,j0,j1,k0,k1
     i0  =               offset6(0,0) + nh_xyz(order_halo(0))
     j0  =               offset6(1,0) + nh_xyz(order_halo(1))
     k0  =               offset6(2,0) + nh_xyz(order_halo(2))
@@ -231,7 +231,7 @@ program main
     j1  =  size(A,2) - offset6(1,1) - nh_xyz(order_halo(1)) - 1
     k1  =  size(A,3) - offset6(2,1) - nh_xyz(order_halo(2)) - 1
     A(i0:i1,j0:j1,k0:k1) = A_ref(i0:i1,j0:j1,k0:k1)
-  end block 
+  end block
 
   ! initialize diezDecomp
   block
@@ -242,12 +242,12 @@ program main
     ! lo_ref: reference [i,j,k] coordinates to track the grid layout for the MPI tasks.
     !     - please note that "lo_xyz" could be used instead of "lo_ref = flat_mpi_ranks(irank,:)"
     !     - both alternatives accomplish the same purpose
-    lo_ref         = flat_mpi_ranks(irank,:) 
+    lo_ref         = flat_mpi_ranks(irank,:)
     call diezdecomp_track_mpi_decomp(lo_ref, obj_ranks, irank, nproc)
     call diezdecomp_generic_fill_hl_obj(hl, obj_ranks, A_shape, offset6, ii, nh_xyz, order_halo, periodic_xyz, wsize,&
                                         use_halo_sync, autotuned_pack)
   end block
-  
+
   ! allocate work buffer
   allocate(work(0:wsize-1))
   work = -1

--- a/examples/transpose/example_1/example_1_transp_xy_8.f90
+++ b/examples/transpose/example_1/example_1_transp_xy_8.f90
@@ -83,24 +83,24 @@ program main
     ! MPI grid layout is:
     ! start (x-aligned pencils): [1, 2, 4]
     ! end   (y-aligned pencils): [2, 1, 4]
-  
+
     pxy        =    2
     pz         =    4
-  
+
     nx_global  =  200
     ny_global  =  320
     nz_global  =  440
-  
+
     nx_in      =  nx_global
     ny_in      =  ny_global/pxy
     nz_in      =  nz_global/pz
-  
+
     nx_out     =  nx_global/pxy
     ny_out     =  ny_global
     nz_out     =  nz_global/pz
-  
+
     ! reference coordinates in n_x/y/z_global
-    block 
+    block
       integer :: i_xy, i_z
       i_xy         =  irank/pz
       i_z          =  mod(irank,pz)
@@ -108,14 +108,14 @@ program main
       if (i_z  >= pz ) error stop 'i_z  >= pz'
       lo_in        =  [0         , i_xy*ny_in, i_z*nz_in ]
       lo_out       =  [i_xy*nx_out,         0, i_z*nz_out]
-    end block 
-  
+    end block
+
    allocate(p_out_ref(0:nx_out-1, 0:ny_out-1, 0:nz_out-1))
    allocate(p_in_out_buf(0:(nx_in*ny_in*nz_in+nx_out*ny_out*nz_out-1)))
 
     p_in (0:nx_in -1, 0:ny_in -1, 0:nz_in -1) => p_in_out_buf(0:(nx_in*ny_in*nz_in-1))
     p_out(0:nx_out-1, 0:ny_out-1, 0:nz_out-1) => p_in_out_buf(nx_in*ny_in*nz_in:(nx_in*ny_in*nz_in+nx_out*ny_out*nz_out-1))
-  
+
     ! define reference input values (p_in)
     block
       integer :: i,j,k,i0,j0,k0
@@ -130,7 +130,7 @@ program main
         end do
       end do
     end block
-  
+
     ! define reference output values (p_out_ref)
     block
       integer :: i,j,k,i0,j0,k0
@@ -182,7 +182,7 @@ program main
 
   ! execute transpose
   call diezdecomp_transp_execute_generic_buf(tr, p_in, p_out, work)
-  
+
   !$acc wait
   !$acc exit data copyout(p_in_out_buf, work)
   !$acc wait
@@ -199,9 +199,9 @@ program main
     error stop 'ERROR: maxval(abs(p_out - p_out_ref)) > 1e-10'
   end if
 
-  if (irank == 0) then 
+  if (irank == 0) then
     write(6,'(A67,E12.4)') 'diezDecomp: example_1_transp_xy_8.f90: SUCCESS!!! error_max:  ', error_max ; flush(6)
-  end if 
+  end if
 
   call MPI_BARRIER(mpi_comm_world, mpi_ierr)
   call MPI_BARRIER(mpi_comm_world, mpi_ierr)

--- a/src/diezdecomp_api_cans.f90
+++ b/src/diezdecomp_api_cans.f90
@@ -335,15 +335,15 @@ module diezdecomp_api_cans
     implicit none
     type(diezdecompGridDesc) :: gd
     real(rp)                 :: p_in(:,:,:), p_out(:,:,:), work(:)
-    integer                  :: ii, jj, kk, ii_jj_kk(0:2), sp_in_full(0:2), sp_out_full(0:2), abs_reorder(0:2), &
-                                offset6_in(0:2,0:1), offset6_out(0:2,0:1), i_halo(0:2), o_halo(0:2), i_pad(0:2), o_pad(0:2)
+    integer                  :: ii, jj, kk, ii_jj_kk(0:2), abs_reorder(0:2), &
+                                offset6_in(0:2,0:1), offset6_out(0:2,0:1), i_halo(0:2), o_halo(0:2), i_pad(0:2), o_pad(0:2), &
+                                zeros6(0:2,0:1)
     logical                  :: allow_alltoallv, is_device_synchronize
     integer(acc_handle_kind) :: stream
     if (.not.(gd%obj_tr(ii,jj)%initialized)) then
       kk       = 3 - ii - jj
       ii_jj_kk = [ii,jj,kk]
-      sp_in_full  = [size(p_in, 1), size(p_in, 2), size(p_in, 3)]
-      sp_out_full = [size(p_out,1), size(p_out,2), size(p_out,3)]
+      zeros6   = 0
       abs_reorder = gd%abs_reorder(ii,jj,:)
       call diezdecomp_fill_transp_props(gd%obj_tr(ii,jj)                            , &
                                         abs_reorder                                 , &
@@ -353,11 +353,9 @@ module diezdecomp_api_cans
                                         gd%all_ap(jj)%lo - 1, gd%all_ap(jj)%hi - 1  , &
                                         ii_jj_kk                                    , &
                                         gd%irank, gd%nproc,allow_alltoallv          , &
-                                        sp_in_full , gd%all_ap(ii)%offset6          , &
-                                        sp_out_full, gd%all_ap(jj)%offset6          , &
+                                        gd%all_ap(ii)%shape, zeros6                 , &
+                                        gd%all_ap(jj)%shape, zeros6                 , &
                                         diezdecomp_allow_autotune_reorder, stream   )
-      gd%obj_tr(ii,jj)%offset6_in  = 0
-      gd%obj_tr(ii,jj)%offset6_out = 0
     end if
     offset6_in  = gd%obj_tr(ii,jj)%offset6_in
     offset6_out = gd%obj_tr(ii,jj)%offset6_out

--- a/src/diezdecomp_api_cans.f90
+++ b/src/diezdecomp_api_cans.f90
@@ -76,103 +76,159 @@ module diezdecomp_api_cans
   contains
 
   ! ---------------------------------------- transpose halos -------------------------------------------
-  function diezdecompTransposeXtoY(ch,gd,pa,pb,work,dtype, stream) result(ierr)
+  function diezdecompTransposeXtoY(ch,gd,pa,pb,work,dtype,&
+                                   input_halo_extents, output_halo_extents, input_padding, output_padding, stream) result(ierr)
     implicit none
     type(diezdecompHandle)             :: ch
-    integer                            :: dtype, ierr
+    integer                            :: dtype, ierr, i_halo(0:2),o_halo(0:2),i_pad(0:2),o_pad(0:2)
     type(diezdecompGridDesc)           :: gd
     real(rp)                           :: pa(:,:,:), pb(:,:,:), work(:)
     integer(acc_handle_kind), optional :: stream
     integer(acc_handle_kind)           :: stream_internal
+    integer, optional                  :: input_halo_extents(0:2)  ,&
+                                          output_halo_extents(0:2) ,&
+                                          input_padding(0:2)       ,&
+                                          output_padding(0:2)
     logical                            :: is_device_synchronize
     stream_internal       = diezdecomp_stream_default
     is_device_synchronize = (.not.present(stream))
     if (present(stream)) stream_internal = stream
+    if (present(input_halo_extents )) then ; i_halo = input_halo_extents  ; else ; i_halo = -1 ; end if
+    if (present(output_halo_extents)) then ; o_halo = output_halo_extents ; else ; o_halo = -1 ; end if
+    if (present(input_padding      )) then ; i_pad  = input_padding       ; else ; i_pad  = -1 ; end if
+    if (present(output_padding     )) then ; o_pad  = output_padding      ; else ; o_pad  = -1 ; end if
     call diezdecomp_boilerplate_transpose(gd, pa, pb, work, 0, 1, diezdecomp_enable_alltoallv, stream_internal, &
-                                          is_device_synchronize)
+                                          is_device_synchronize, i_halo, o_halo, i_pad, o_pad)
     ierr = 0
   end function
 
-  function diezdecompTransposeYtoX(ch,gd,pa,pb,work,dtype, stream) result(ierr)
+  function diezdecompTransposeYtoX(ch,gd,pa,pb,work,dtype,&
+                                   input_halo_extents, output_halo_extents, input_padding, output_padding, stream) result(ierr)
     implicit none
     type(diezdecompHandle)             :: ch
-    integer                            :: dtype, ierr
+    integer                            :: dtype, ierr, i_halo(0:2),o_halo(0:2),i_pad(0:2),o_pad(0:2)
     type(diezdecompGridDesc)           :: gd
     real(rp)                           :: pa(:,:,:), pb(:,:,:), work(:)
     integer(acc_handle_kind), optional :: stream
     integer(acc_handle_kind)           :: stream_internal
+    integer, optional                  :: input_halo_extents(0:2)  ,&
+                                          output_halo_extents(0:2) ,&
+                                          input_padding(0:2)       ,&
+                                          output_padding(0:2)
     logical                            :: is_device_synchronize
     stream_internal       = diezdecomp_stream_default
     is_device_synchronize = (.not.present(stream))
     if (present(stream)) stream_internal = stream
+    if (present(input_halo_extents )) then ; i_halo = input_halo_extents  ; else ; i_halo = -1 ; end if
+    if (present(output_halo_extents)) then ; o_halo = output_halo_extents ; else ; o_halo = -1 ; end if
+    if (present(input_padding      )) then ; i_pad  = input_padding       ; else ; i_pad  = -1 ; end if
+    if (present(output_padding     )) then ; o_pad  = output_padding      ; else ; o_pad  = -1 ; end if
     call diezdecomp_boilerplate_transpose(gd, pa, pb, work, 1, 0, diezdecomp_enable_alltoallv, stream_internal, &
-                                          is_device_synchronize)
+                                          is_device_synchronize, i_halo, o_halo, i_pad, o_pad)
     ierr = 0
   end function
 
-  function diezdecompTransposeYtoZ(ch,gd,pa,pb,work,dtype, stream) result(ierr)
+  function diezdecompTransposeYtoZ(ch,gd,pa,pb,work,dtype,&
+                                   input_halo_extents, output_halo_extents, input_padding, output_padding, stream) result(ierr)
     implicit none
     type(diezdecompHandle)             :: ch
-    integer                            :: dtype, ierr
+    integer                            :: dtype, ierr, i_halo(0:2),o_halo(0:2),i_pad(0:2),o_pad(0:2)
     type(diezdecompGridDesc)           :: gd
     real(rp)                           :: pa(:,:,:), pb(:,:,:), work(:)
     integer(acc_handle_kind), optional :: stream
     integer(acc_handle_kind)           :: stream_internal
+    integer, optional                  :: input_halo_extents(0:2)  ,&
+                                          output_halo_extents(0:2) ,&
+                                          input_padding(0:2)       ,&
+                                          output_padding(0:2)
     logical                            :: is_device_synchronize
     stream_internal       = diezdecomp_stream_default
     is_device_synchronize = (.not.present(stream))
     if (present(stream)) stream_internal = stream
+    if (present(input_halo_extents )) then ; i_halo = input_halo_extents  ; else ; i_halo = -1 ; end if
+    if (present(output_halo_extents)) then ; o_halo = output_halo_extents ; else ; o_halo = -1 ; end if
+    if (present(input_padding      )) then ; i_pad  = input_padding       ; else ; i_pad  = -1 ; end if
+    if (present(output_padding     )) then ; o_pad  = output_padding      ; else ; o_pad  = -1 ; end if
     call diezdecomp_boilerplate_transpose(gd, pa, pb, work, 1, 2, diezdecomp_enable_alltoallv, stream_internal, &
-                                          is_device_synchronize)
+                                          is_device_synchronize, i_halo, o_halo, i_pad, o_pad)
     ierr = 0
   end function
 
-  function diezdecompTransposeZtoY(ch,gd,pa,pb,work,dtype, stream) result(ierr)
+  function diezdecompTransposeZtoY(ch,gd,pa,pb,work,dtype,&
+                                   input_halo_extents, output_halo_extents, input_padding, output_padding, stream) result(ierr)
     implicit none
     type(diezdecompHandle)             :: ch
-    integer                            :: dtype, ierr
+    integer                            :: dtype, ierr, i_halo(0:2),o_halo(0:2),i_pad(0:2),o_pad(0:2)
     type(diezdecompGridDesc)           :: gd
     real(rp)                           :: pa(:,:,:), pb(:,:,:), work(:)
     integer(acc_handle_kind), optional :: stream
     integer(acc_handle_kind)           :: stream_internal
+    integer, optional                  :: input_halo_extents(0:2)  ,&
+                                          output_halo_extents(0:2) ,&
+                                          input_padding(0:2)       ,&
+                                          output_padding(0:2)
     logical                            :: is_device_synchronize
     stream_internal       = diezdecomp_stream_default
     is_device_synchronize = (.not.present(stream))
     if (present(stream)) stream_internal = stream
+    if (present(input_halo_extents )) then ; i_halo = input_halo_extents  ; else ; i_halo = -1 ; end if
+    if (present(output_halo_extents)) then ; o_halo = output_halo_extents ; else ; o_halo = -1 ; end if
+    if (present(input_padding      )) then ; i_pad  = input_padding       ; else ; i_pad  = -1 ; end if
+    if (present(output_padding     )) then ; o_pad  = output_padding      ; else ; o_pad  = -1 ; end if
     call diezdecomp_boilerplate_transpose(gd, pa, pb, work, 2, 1, diezdecomp_enable_alltoallv, stream_internal, &
-                                          is_device_synchronize)
+                                          is_device_synchronize, i_halo, o_halo, i_pad, o_pad)
     ierr = 0
   end function
 
-  function diezdecompTransposeXtoZ(ch,gd,pa,pb,work,dtype, stream) result(ierr)
+  function diezdecompTransposeXtoZ(ch,gd,pa,pb,work,dtype,&
+                                   input_halo_extents, output_halo_extents, input_padding, output_padding, stream) result(ierr)
     implicit none
     type(diezdecompHandle)             :: ch
-    integer                            :: dtype, ierr
+    integer                            :: dtype, ierr, i_halo(0:2),o_halo(0:2),i_pad(0:2),o_pad(0:2)
     type(diezdecompGridDesc)           :: gd
     real(rp)                           :: pa(:,:,:), pb(:,:,:), work(:)
     integer(acc_handle_kind), optional :: stream
     integer(acc_handle_kind)           :: stream_internal
+    integer, optional                  :: input_halo_extents(0:2)  ,&
+                                          output_halo_extents(0:2) ,&
+                                          input_padding(0:2)       ,&
+                                          output_padding(0:2)
     logical                            :: is_device_synchronize
     stream_internal       = diezdecomp_stream_default
     is_device_synchronize = (.not.present(stream))
     if (present(stream)) stream_internal = stream
-    call diezdecomp_boilerplate_transpose(gd, pa, pb, work, 0, 2,.false., stream_internal, is_device_synchronize)
+    if (present(input_halo_extents )) then ; i_halo = input_halo_extents  ; else ; i_halo = -1 ; end if
+    if (present(output_halo_extents)) then ; o_halo = output_halo_extents ; else ; o_halo = -1 ; end if
+    if (present(input_padding      )) then ; i_pad  = input_padding       ; else ; i_pad  = -1 ; end if
+    if (present(output_padding     )) then ; o_pad  = output_padding      ; else ; o_pad  = -1 ; end if
+    call diezdecomp_boilerplate_transpose(gd, pa, pb, work, 0, 2,.false., stream_internal, &
+                                          is_device_synchronize, i_halo, o_halo, i_pad, o_pad)
     ierr = 0
   end function
 
-  function diezdecompTransposeZtoX(ch,gd,pa,pb,work,dtype, stream) result(ierr)
+  function diezdecompTransposeZtoX(ch,gd,pa,pb,work,dtype,&
+                                   input_halo_extents, output_halo_extents, input_padding, output_padding, stream) result(ierr)
     implicit none
     type(diezdecompHandle)             :: ch
-    integer                            :: dtype, ierr
+    integer                            :: dtype, ierr, i_halo(0:2),o_halo(0:2),i_pad(0:2),o_pad(0:2)
     type(diezdecompGridDesc)           :: gd
     real(rp)                           :: pa(:,:,:), pb(:,:,:), work(:)
     integer(acc_handle_kind), optional :: stream
     integer(acc_handle_kind)           :: stream_internal
+    integer, optional                  :: input_halo_extents(0:2)  ,&
+                                          output_halo_extents(0:2) ,&
+                                          input_padding(0:2)       ,&
+                                          output_padding(0:2)
     logical                            :: is_device_synchronize
     stream_internal       = diezdecomp_stream_default
     is_device_synchronize = (.not.present(stream))
     if (present(stream)) stream_internal = stream
-    call diezdecomp_boilerplate_transpose(gd, pa, pb, work, 2, 0,.false., stream_internal, is_device_synchronize)
+    if (present(input_halo_extents )) then ; i_halo = input_halo_extents  ; else ; i_halo = -1 ; end if
+    if (present(output_halo_extents)) then ; o_halo = output_halo_extents ; else ; o_halo = -1 ; end if
+    if (present(input_padding      )) then ; i_pad  = input_padding       ; else ; i_pad  = -1 ; end if
+    if (present(output_padding     )) then ; o_pad  = output_padding      ; else ; o_pad  = -1 ; end if
+    call diezdecomp_boilerplate_transpose(gd, pa, pb, work, 2, 0,.false., stream_internal, &
+                                          is_device_synchronize, i_halo, o_halo, i_pad, o_pad)
     ierr = 0
   end function
 
@@ -275,11 +331,12 @@ module diezdecomp_api_cans
 
   ! ---------------------------------------- boilerplate transpose/halos -------------------------------------------
   subroutine diezdecomp_boilerplate_transpose(gd, p_in, p_out, work, ii, jj, &
-                                              allow_alltoallv, stream, is_device_synchronize)
+                                              allow_alltoallv, stream, is_device_synchronize, i_halo, o_halo, i_pad, o_pad)
     implicit none
     type(diezdecompGridDesc) :: gd
     real(rp)                 :: p_in(:,:,:), p_out(:,:,:), work(:)
-    integer                  :: ii, jj, kk, ii_jj_kk(0:2), sp_in_full(0:2), sp_out_full(0:2), abs_reorder(0:2)
+    integer                  :: ii, jj, kk, ii_jj_kk(0:2), sp_in_full(0:2), sp_out_full(0:2), abs_reorder(0:2), &
+                                offset6_in(0:2,0:1), offset6_out(0:2,0:1), i_halo(0:2), o_halo(0:2), i_pad(0:2), o_pad(0:2)
     logical                  :: allow_alltoallv, is_device_synchronize
     integer(acc_handle_kind) :: stream
     if (.not.(gd%obj_tr(ii,jj)%initialized)) then
@@ -300,7 +357,19 @@ module diezdecomp_api_cans
                                         sp_out_full, gd%all_ap(jj)%offset6          , &
                                         diezdecomp_allow_autotune_reorder, stream   )
     end if
+    offset6_in  = gd%obj_tr(ii,jj)%offset6_in
+    offset6_out = gd%obj_tr(ii,jj)%offset6_out
+    if ((i_halo(0)>=0).and.(i_pad(0)>=0)) then
+      gd%obj_tr(ii,jj)%offset6_in(:,0)  =  i_halo
+      gd%obj_tr(ii,jj)%offset6_in(:,1)  =  i_halo + i_pad
+    end if
+    if ((o_halo(0)>=0).and.(o_pad(0)>=0)) then
+      gd%obj_tr(ii,jj)%offset6_out(:,0)  =  o_halo
+      gd%obj_tr(ii,jj)%offset6_out(:,1)  =  o_halo + o_pad
+    end if
     call diezdecomp_transp_execute(gd%obj_tr(ii,jj), p_in, p_out, stream, work)
+    gd%obj_tr(ii,jj)%offset6_in  = offset6_in
+    gd%obj_tr(ii,jj)%offset6_out = offset6_out
     if (is_device_synchronize) then
       !$acc wait(stream)
     end if

--- a/src/diezdecomp_api_cans.f90
+++ b/src/diezdecomp_api_cans.f90
@@ -427,6 +427,17 @@ module diezdecomp_api_cans
       call summary_cudecompGetPencilInfo(gd%all_ap(axis), axis, pdims, gdims, gdims_dist, transpose_axis_contiguous, periods, &
                                         ipencil, offset6_xyz, gd%irank, gd%nproc)
     end do
+    block 
+      integer :: i,j,k
+      do     i=0,2
+        do   j=0,2
+          do k=0,2
+            ! default initialization: gd%abs_reorder matches output "internal_order"
+            gd%abs_reorder(i,j,k) = gd%all_ap(j)%internal_order(k+1)
+          end do 
+        end do 
+      end do 
+    end block 
   end subroutine
 
   function diezdecompGetPencilInfo(ch, gd ,ap, axis)  result(ierr)

--- a/src/diezdecomp_api_cans.f90
+++ b/src/diezdecomp_api_cans.f90
@@ -356,6 +356,8 @@ module diezdecomp_api_cans
                                         sp_in_full , gd%all_ap(ii)%offset6          , &
                                         sp_out_full, gd%all_ap(jj)%offset6          , &
                                         diezdecomp_allow_autotune_reorder, stream   )
+      gd%obj_tr(ii,jj)%offset6_in  = 0
+      gd%obj_tr(ii,jj)%offset6_out = 0
     end if
     offset6_in  = gd%obj_tr(ii,jj)%offset6_in
     offset6_out = gd%obj_tr(ii,jj)%offset6_out

--- a/tests/halo/halos_asym.py
+++ b/tests/halo/halos_asym.py
@@ -227,13 +227,14 @@ def main_runner():
             fname   =  lambda irank,key: pjoin(input_folder, f'input_{irank:06d}{padstr(key,12)}.dat')
             buffer  =  {}
             for D in saved_fields.values():
-                pads_x                   =  [random.randint(0,4) for _ in range(6)]
+                pads_x, pads_x_noise     =  [[random.randint(0,4) for _ in range(6)] for _ in range(2)]
                 buffer[D['irank']]       = dict(info=[f"{ii} {axis} {int(use_halo_sync)} {int(pack_type)} {int(mode_api_cans)} ! ii axis use_halo_sync pack_type mode_api_cans"    ,
                                                       ' '.join(map(str,abs_order)) + ' ! abs_order'                                                     ,
                                                       ' '.join(map(str,nh_xyz))    + ' ! nh_xyz'                                                        ,
                                                       ' '.join(map(str,np.array(np.where(mpi_ranks_ii==D['irank'])).reshape(-1).tolist())) + ' ! lo_xyz',
                                                       str(int(is_per))                                                                     + ' ! is_per',
-                                                      ' '.join(map(str, pads_x     )) + ' ! pads_x',
+                                                      ' '.join(map(str, pads_x       )) + ' ! pads_x',
+                                                      ' '.join(map(str, pads_x_noise )) + ' ! pads_x_noise',
                                                       *writer_nd(padded(clean_borders(D['px'], nh_xyz,ii,is_per,abs_order),pads_x,seed=seed), 'px_padded'    )                                                     ,
                                                       *writer_nd(padded(D['px_ref'],pads_x,seed=seed), 'px_padded_ref')                                                     ])
             print('Writing trial folder: ', trial_folder)

--- a/tests/halo/halos_asym.py
+++ b/tests/halo/halos_asym.py
@@ -195,7 +195,7 @@ def main_runner():
         
         def get_ref_incomplete():
             all_p_xyz_incomplete  =  mk_rand_shards(nh_xyz, pieces_xyz)
-            all_px_shape          =  {key: [arr[k] for arr in [np.array(val.shape)-2*np.array(nh_xyz)] for k in abs_order] 
+            all_px_shape          =  {key: [arr[k] for arr in [np.array(val.shape)-2*np.array(nh_xyz)] for k in abs_order]
                                       for key,val in all_p_xyz_incomplete.items()}
 
             all_p_xyz_ref         =  quick_halo_propagate(all_p_xyz_incomplete, nh_xyz, is_per, ii)

--- a/tests/transpose/main_transp.f90
+++ b/tests/transpose/main_transp.f90
@@ -160,7 +160,7 @@ program main
     gd%all_ap(jj)%lo(1:3)  =  lo_b(0:2) + 1
     gd%all_ap(jj)%hi(1:3)  =  hi_b(0:2) + 1
 
-    if (use_cans_change_offsets) then 
+    if (use_cans_change_offsets) then
       gd%all_ap(ii)%offset6  =  offset6_in_bad
       gd%all_ap(jj)%offset6  =  offset6_out_bad
     else
@@ -215,13 +215,13 @@ program main
 
 
   if (mode_api_cans) then
-    block 
+    block
       integer :: i_halo(0:2), o_halo(0:2), i_pad(0:2), o_pad(0:2)
       i_halo = -1
       o_halo = -1
       i_pad  = -1
       o_pad  = -1
-      if (use_cans_change_offsets) then 
+      if (use_cans_change_offsets) then
         allocate(px_bad(0:(sx0 -  offset6_in(0,0) -  offset6_in(0,1) +  offset6_in_bad(0,0) +  offset6_in_bad(0,1) )-1,&
                         0:(sx1 -  offset6_in(1,0) -  offset6_in(1,1) +  offset6_in_bad(1,0) +  offset6_in_bad(1,1) )-1,&
                         0:(sx2 -  offset6_in(2,0) -  offset6_in(2,1) +  offset6_in_bad(2,0) +  offset6_in_bad(2,1) )-1),&
@@ -234,7 +234,7 @@ program main
         call diezDecomp_boilerplate_transpose(gd, px, py, buffer, ii, jj,allow_alltoallv, stream, .false., &
                                               i_halo, o_halo, i_pad, o_pad)
       end if
-    end block 
+    end block
     !$acc wait
     associate(obj => gd%obj_tr(ii,jj))
       if (force_send_autotune==1) then
@@ -297,9 +297,9 @@ program main
   !$acc wait
   elapse_time = MPI_Wtime()
   if (mode_api_cans)  then
-    block 
+    block
       integer :: i_halo(0:2), o_halo(0:2), i_pad(0:2), o_pad(0:2)
-      if (use_cans_change_offsets) then 
+      if (use_cans_change_offsets) then
         i_pad  = offset6_in(:,1) - offset6_in(:,0)
         i_halo = offset6_in(:,1) - i_pad
         o_pad  = offset6_out(:,1) - offset6_out(:,0)
@@ -314,7 +314,7 @@ program main
         call diezDecomp_boilerplate_transpose(gd, px, py, buffer, ii, jj,allow_alltoallv, stream, .false., &
                                               i_halo, o_halo, i_pad, o_pad)
       end if
-    end block 
+    end block
   else
     if (mode_use_buf) then
       call diezdecomp_transp_execute_generic_buf(tr, px, py, buffer, stream)

--- a/tests/transpose/main_transp.f90
+++ b/tests/transpose/main_transp.f90
@@ -28,14 +28,12 @@ program main
                                         read_int1, read_int2, read_int3, read_int4, read_int5, &
                                         send_autotuned, recv_autotuned, send_mode_op_simul, recv_mode_op_simul,&
                                         force_send_autotune, force_recv_autotune, offset6_in(0:2,0:1), offset6_out(0:2,0:1), &
-                                        offset6_in_bad(0:2,0:1), offset6_out_bad(0:2,0:1), &
                                         send_mode_op_batched, recv_mode_op_batched,i0,i1,j0,j1,k0,k1
-  logical                           ::  allow_alltoallv, mode_api_cans, allow_autotune_reorder, mode_use_buf, &
-                                        use_cans_change_offsets
+  logical                           ::  allow_alltoallv, mode_api_cans, allow_autotune_reorder, mode_use_buf
   character(len=62)                 ::  fname_62
   character(len=11)                 ::  fname_11
   real(rp)                          ::  read_real, elapse_time
-  real(rp), allocatable, target     ::  py_ref(:,:,:), buffer(:), px_orig(:,:,:), py_buf(:), px_buf(:), px_bad(:,:,:), py_bad(:,:,:)
+  real(rp), allocatable, target     ::  py_ref(:,:,:), buffer(:), px_orig(:,:,:), py_buf(:), px_buf(:)
   real(rp), pointer                 ::  py(:,:,:), px(:,:,:)
   integer(i8)                       ::  wsize
   type(diezdecomp_props_transp)     ::  tr
@@ -97,11 +95,6 @@ program main
         read(54,*) hi_b
         read(54,*) offset6_in
         read(54,*) offset6_out
-        read(54,*) read_int5
-        use_cans_change_offsets = (read_int5==1)
-        read(54,*) offset6_in_bad
-        read(54,*) offset6_out_bad
-
         read(54,*) sx0,sx1,sx2
         allocate(px_orig(0:sx0-1,0:sx1-1,0:sx2-1))
         do iter=1,(sx0*sx1*sx2)
@@ -159,14 +152,8 @@ program main
     gd%all_ap(ii)%hi(1:3)  =  hi_a(0:2) + 1
     gd%all_ap(jj)%lo(1:3)  =  lo_b(0:2) + 1
     gd%all_ap(jj)%hi(1:3)  =  hi_b(0:2) + 1
-
-    if (use_cans_change_offsets) then
-      gd%all_ap(ii)%offset6  =  offset6_in_bad
-      gd%all_ap(jj)%offset6  =  offset6_out_bad
-    else
-      gd%all_ap(ii)%offset6  =  offset6_in
-      gd%all_ap(jj)%offset6  =  offset6_out
-    end if
+    gd%all_ap(ii)%shape =  gd%all_ap(ii)%hi - gd%all_ap(ii)%lo + 1
+    gd%all_ap(jj)%shape =  gd%all_ap(jj)%hi - gd%all_ap(jj)%lo + 1
 
     gd%irank                           =  irank
     gd%nproc                           =  nproc
@@ -215,26 +202,6 @@ program main
 
 
   if (mode_api_cans) then
-    block
-      integer :: i_halo(0:2), o_halo(0:2), i_pad(0:2), o_pad(0:2)
-      i_halo = -1
-      o_halo = -1
-      i_pad  = -1
-      o_pad  = -1
-      if (use_cans_change_offsets) then
-        allocate(px_bad(0:(sx0 -  offset6_in(0,0) -  offset6_in(0,1) +  offset6_in_bad(0,0) +  offset6_in_bad(0,1) )-1,&
-                        0:(sx1 -  offset6_in(1,0) -  offset6_in(1,1) +  offset6_in_bad(1,0) +  offset6_in_bad(1,1) )-1,&
-                        0:(sx2 -  offset6_in(2,0) -  offset6_in(2,1) +  offset6_in_bad(2,0) +  offset6_in_bad(2,1) )-1),&
-                 py_bad(0:(sy0 - offset6_out(0,0) - offset6_out(0,1) + offset6_out_bad(0,0) + offset6_out_bad(0,1) )-1,&
-                        0:(sy1 - offset6_out(1,0) - offset6_out(1,1) + offset6_out_bad(1,0) + offset6_out_bad(1,1) )-1,&
-                        0:(sy2 - offset6_out(2,0) - offset6_out(2,1) + offset6_out_bad(2,0) + offset6_out_bad(2,1) )-1))
-        call diezDecomp_boilerplate_transpose(gd, px_bad, py_bad, buffer, ii, jj,allow_alltoallv, stream, .false., &
-                                              i_halo, o_halo, i_pad, o_pad)
-      else
-        call diezDecomp_boilerplate_transpose(gd, px, py, buffer, ii, jj,allow_alltoallv, stream, .false., &
-                                              i_halo, o_halo, i_pad, o_pad)
-      end if
-    end block
     !$acc wait
     associate(obj => gd%obj_tr(ii,jj))
       if (force_send_autotune==1) then
@@ -248,7 +215,6 @@ program main
         obj%recv_mode_op_batched = recv_mode_op_batched
       end if
       write(6,*) irank,'mode_api_cans'           , mode_api_cans            ;flush(6)
-      write(6,*) irank,'use_cans_change_offsets' , use_cans_change_offsets  ;flush(6)
       write(6,*) irank,'mode_use_buf'            , mode_use_buf             ;flush(6)
       write(6,*) irank,'force_send_autotune'     , force_send_autotune      ;flush(6)
       write(6,*) irank,'obj%send_autotuned'      , obj%send_autotuned       ;flush(6)
@@ -272,7 +238,6 @@ program main
         obj%recv_mode_op_batched = recv_mode_op_batched
       end if
       write(6,*) irank,'mode_api_cans'           , mode_api_cans            ;flush(6)
-      write(6,*) irank,'use_cans_change_offsets' , use_cans_change_offsets  ;flush(6)
       write(6,*) irank,'mode_use_buf'            , mode_use_buf             ;flush(6)
       write(6,*) irank,'force_send_autotune'     , force_send_autotune      ;flush(6)
       write(6,*) irank,'obj%send_autotuned'      , obj%send_autotuned       ;flush(6)
@@ -299,21 +264,12 @@ program main
   if (mode_api_cans)  then
     block
       integer :: i_halo(0:2), o_halo(0:2), i_pad(0:2), o_pad(0:2)
-      if (use_cans_change_offsets) then
-        i_pad  = offset6_in(:,1) - offset6_in(:,0)
-        i_halo = offset6_in(:,1) - i_pad
-        o_pad  = offset6_out(:,1) - offset6_out(:,0)
-        o_halo = offset6_out(:,1) - o_pad
-        call diezDecomp_boilerplate_transpose(gd, px, py, buffer, ii, jj,allow_alltoallv, stream, .false., &
-                                              i_halo, o_halo, i_pad, o_pad)
-      else
-        i_halo = -1
-        o_halo = -1
-        i_pad  = -1
-        o_pad  = -1
-        call diezDecomp_boilerplate_transpose(gd, px, py, buffer, ii, jj,allow_alltoallv, stream, .false., &
-                                              i_halo, o_halo, i_pad, o_pad)
-      end if
+      i_pad  = offset6_in(:,1) - offset6_in(:,0)
+      i_halo = offset6_in(:,1) - i_pad
+      o_pad  = offset6_out(:,1) - offset6_out(:,0)
+      o_halo = offset6_out(:,1) - o_pad
+      call diezDecomp_boilerplate_transpose(gd, px, py, buffer, ii, jj,allow_alltoallv, stream, .false., &
+                                            i_halo, o_halo, i_pad, o_pad)
     end block
   else
     if (mode_use_buf) then

--- a/tests/transpose/transposes.py
+++ b/tests/transpose/transposes.py
@@ -216,7 +216,7 @@ def main_runner():
             if use_cans_change_offsets:
                 def fix_pad():
                     # pads_? is [h h h h+p h+p h+p]
-                    # initially is h h h p p p 
+                    # initially is h h h p p p
                     for j in range(3,6):
                         pads_x[j] += pads_x[j-3]
                         pads_y[j] += pads_y[j-3]

--- a/tests/transpose/transposes.py
+++ b/tests/transpose/transposes.py
@@ -207,14 +207,24 @@ def main_runner():
         fname         =  lambda irank,key: pjoin(input_folder, f'input_{irank:06d}{padstr(key,12)}.dat')
         buffer        =  {}
         for key,(px,lo_a,hi_a) in p_xyz_ii.items():
-            irank           =  ranks_ii[key]
-            (py,lo_b,hi_b), =  [val for key,val in p_xyz_jj.items() if (ranks_jj[key]==irank)]
-            loc_order_a     =  loc_order_ii
-            loc_order_b     =  loc_order_jj
-            pads_x, pads_y  =  [[random.randint(0,4) for _ in range(6)] for _ in range(2)]
-            autotune_opts   = lambda: [random.randint(0,1), random.randint(1,2), random.randint(1,6), random.randint(1,6)]
+            irank                                 =  ranks_ii[key]
+            (py,lo_b,hi_b),                       =  [val for key,val in p_xyz_jj.items() if (ranks_jj[key]==irank)]
+            loc_order_a                           =  loc_order_ii
+            loc_order_b                           =  loc_order_jj
+            pads_x, pads_y,pads_x_bad,pads_y_bad  =  [[random.randint(0,4) for _ in range(6)] for _ in range(4)]
+            use_cans_change_offsets               =  random.randint(0,1)
+            if use_cans_change_offsets:
+                def fix_pad():
+                    # pads_? is [h h h h+p h+p h+p]
+                    # initially is h h h p p p 
+                    for j in range(3,6):
+                        pads_x[j] += pads_x[j-3]
+                        pads_y[j] += pads_y[j-3]
+                fix_pad()
+            autotune_opts                         =  lambda: [random.randint(0,1), random.randint(1,2), random.randint(1,6), random.randint(1,6)]
             force_send_autotune, send_autotuned, send_mode_op_simul, send_mode_op_batched = autotune_opts()
             force_recv_autotune, recv_autotuned, recv_mode_op_simul, recv_mode_op_batched = autotune_opts()
+
             all_modeops     =  [f"{force_send_autotune} {force_recv_autotune} ! force_send_autotune force_recv_autotune",
                                 f'{send_autotuned} {recv_autotuned} ! send_autotuned recv_autotuned',
                                 f"{send_mode_op_simul} {recv_mode_op_simul} ! send_mode_op_simul recv_mode_op_simul",
@@ -227,8 +237,13 @@ def main_runner():
                                               ' '.join(map(str,lo_b))        + ' ! lo_b'       ,
                                               ' '.join(map(str,hi_a))        + ' ! hi_a'       ,
                                               ' '.join(map(str,hi_b))        + ' ! hi_b'       ,
-                                              ' '.join(map(str, pads_x     )) + ' ! pads_x',
-                                              ' '.join(map(str, pads_y     )) + ' ! pads_y',
+                                              ' '.join(map(str, pads_x    )) + ' ! pads_x',
+                                              ' '.join(map(str, pads_y    )) + ' ! pads_y',
+
+                                             f'{int(use_cans_change_offsets)} ! use_cans_change_offsets' ,
+                                              ' '.join(map(str, pads_x_bad)) + ' ! pads_x_bad',
+                                              ' '.join(map(str, pads_y_bad)) + ' ! pads_y_bad',
+
                                               *writer_nd(padded(px,pads_x), 'px_padded') ,
                                               *writer_nd(padded(py,pads_y), 'py_padded') ,
                                               *all_modeops                                     ])

--- a/tests/transpose/transposes.py
+++ b/tests/transpose/transposes.py
@@ -159,11 +159,11 @@ def main_runner():
                 div_xyz_ii      =  [random.randint(1,divmax)      for _ in range(3)]
                 n_xyz           =  [random.randint(d,d*nloc_max)  for d in div_xyz_ii]
                 div_xyz_ii[ii]  =  1
-                nproc           =  np.product(div_xyz_ii)
+                nproc           =  np.prod(div_xyz_ii)
 
             if any_to_any:
                 div_xyz_jj = [float('inf')]
-                while np.product(div_xyz_jj) != nproc:
+                while np.prod(div_xyz_jj) != nproc:
                     div_xyz_jj      =  [random.randint(1,divmax)      for _ in range(3)]
                     div_xyz_jj[jj]  =  1
             else:
@@ -207,20 +207,18 @@ def main_runner():
         fname         =  lambda irank,key: pjoin(input_folder, f'input_{irank:06d}{padstr(key,12)}.dat')
         buffer        =  {}
         for key,(px,lo_a,hi_a) in p_xyz_ii.items():
-            irank                                 =  ranks_ii[key]
-            (py,lo_b,hi_b),                       =  [val for key,val in p_xyz_jj.items() if (ranks_jj[key]==irank)]
-            loc_order_a                           =  loc_order_ii
-            loc_order_b                           =  loc_order_jj
-            pads_x, pads_y,pads_x_bad,pads_y_bad  =  [[random.randint(0,4) for _ in range(6)] for _ in range(4)]
-            use_cans_change_offsets               =  random.randint(0,1)
-            if use_cans_change_offsets:
-                def fix_pad():
-                    # pads_? is [h h h h+p h+p h+p]
-                    # initially is h h h p p p
-                    for j in range(3,6):
-                        pads_x[j] += pads_x[j-3]
-                        pads_y[j] += pads_y[j-3]
-                fix_pad()
+            irank            =  ranks_ii[key]
+            (py,lo_b,hi_b),  =  [val for key,val in p_xyz_jj.items() if (ranks_jj[key]==irank)]
+            loc_order_a      =  loc_order_ii
+            loc_order_b      =  loc_order_jj
+            pads_x, pads_y   =  [[random.randint(0,4) for _ in range(6)] for _ in range(2)]
+            def fix_pad():
+                # pads_? is [h h h h+p h+p h+p]
+                # initially is h h h p p p
+                for j in range(3,6):
+                    pads_x[j] += pads_x[j-3]
+                    pads_y[j] += pads_y[j-3]
+            fix_pad()
             autotune_opts                         =  lambda: [random.randint(0,1), random.randint(1,2), random.randint(1,6), random.randint(1,6)]
             force_send_autotune, send_autotuned, send_mode_op_simul, send_mode_op_batched = autotune_opts()
             force_recv_autotune, recv_autotuned, recv_mode_op_simul, recv_mode_op_batched = autotune_opts()
@@ -237,15 +235,10 @@ def main_runner():
                                               ' '.join(map(str,lo_b))        + ' ! lo_b'       ,
                                               ' '.join(map(str,hi_a))        + ' ! hi_a'       ,
                                               ' '.join(map(str,hi_b))        + ' ! hi_b'       ,
-                                              ' '.join(map(str, pads_x    )) + ' ! pads_x',
-                                              ' '.join(map(str, pads_y    )) + ' ! pads_y',
-
-                                             f'{int(use_cans_change_offsets)} ! use_cans_change_offsets' ,
-                                              ' '.join(map(str, pads_x_bad)) + ' ! pads_x_bad',
-                                              ' '.join(map(str, pads_y_bad)) + ' ! pads_y_bad',
-
-                                              *writer_nd(padded(px,pads_x), 'px_padded') ,
-                                              *writer_nd(padded(py,pads_y), 'py_padded') ,
+                                              ' '.join(map(str, pads_x    )) + ' ! pads_x'     ,
+                                              ' '.join(map(str, pads_y    )) + ' ! pads_y'     ,
+                                              *writer_nd(padded(px,pads_x), 'px_padded')       ,
+                                              *writer_nd(padded(py,pads_y), 'py_padded')       ,
                                               *all_modeops                                     ])
         print('Writing trial folder: ', trial_folder)
         writer_base(fname, buffer)

--- a/tests/transpose/transposes.py
+++ b/tests/transpose/transposes.py
@@ -211,7 +211,8 @@ def main_runner():
             (py,lo_b,hi_b),  =  [val for key,val in p_xyz_jj.items() if (ranks_jj[key]==irank)]
             loc_order_a      =  loc_order_ii
             loc_order_b      =  loc_order_jj
-            pads_x, pads_y   =  [[random.randint(0,4) for _ in range(6)] for _ in range(2)]
+            (pads_x      , pads_y,
+             pads_x_noise, pads_y_noise)  =  [[random.randint(0,4) for _ in range(6)] for _ in range(4)]
             def fix_pad():
                 # pads_? is [h h h h+p h+p h+p]
                 # initially is h h h p p p
@@ -228,15 +229,17 @@ def main_runner():
                                 f"{send_mode_op_simul} {recv_mode_op_simul} ! send_mode_op_simul recv_mode_op_simul",
                                 f"{send_mode_op_batched} {recv_mode_op_batched} ! send_mode_op_batched recv_mode_op_batched"]
             buffer[irank]   =  dict(info  =  [f"{ii} {jj} {kk} {use_alltoallv} {mode_api_cans} {allow_autotune_reorder} {mode_use_buf} ! ii jj kk use_alltoallv mode_api_cans allow_autotune_reorder mode_use_buf"               ,
-                                              ' '.join(map(str,loc_order_a)) + ' ! loc_order_a',
-                                              ' '.join(map(str,loc_order_b)) + ' ! loc_order_b',
-                                              ' '.join(map(str,abs_reorder)) + ' ! abs_reorder',
-                                              ' '.join(map(str,lo_a))        + ' ! lo_a'       ,
-                                              ' '.join(map(str,lo_b))        + ' ! lo_b'       ,
-                                              ' '.join(map(str,hi_a))        + ' ! hi_a'       ,
-                                              ' '.join(map(str,hi_b))        + ' ! hi_b'       ,
-                                              ' '.join(map(str, pads_x    )) + ' ! pads_x'     ,
-                                              ' '.join(map(str, pads_y    )) + ' ! pads_y'     ,
+                                              ' '.join(map(str,loc_order_a))   + ' ! loc_order_a' ,
+                                              ' '.join(map(str,loc_order_b))   + ' ! loc_order_b' ,
+                                              ' '.join(map(str,abs_reorder))   + ' ! abs_reorder' ,
+                                              ' '.join(map(str,lo_a))          + ' ! lo_a'        ,
+                                              ' '.join(map(str,lo_b))          + ' ! lo_b'        ,
+                                              ' '.join(map(str,hi_a))          + ' ! hi_a'        ,
+                                              ' '.join(map(str,hi_b))          + ' ! hi_b'        ,
+                                              ' '.join(map(str, pads_x    ))   + ' ! pads_x'      ,
+                                              ' '.join(map(str, pads_y    ))   + ' ! pads_y'      ,
+                                              ' '.join(map(str, pads_x_noise)) + ' ! pads_x_noise',
+                                              ' '.join(map(str, pads_y_noise)) + ' ! pads_y_noise',
                                               *writer_nd(padded(px,pads_x), 'px_padded')       ,
                                               *writer_nd(padded(py,pads_y), 'py_padded')       ,
                                               *all_modeops                                     ])


### PR DESCRIPTION
* Added support for variable halo and padding offsets in the `api_cans.f90` and `api_generic.f90`.
   * For instance, if an array `P` is defined multiple times:
     *  Standard array: `P_normal(0:n-1,0:n-1,0:n-1)`
      * Version with periodicity: `P_periodic(-1:n,-1:n,-1:n)`.
      * Version with extra cells for FFT subroutines (unused afterwards): `P_fft(0:n_fft,0:n_fft,0:n-1)`.
   * The new `diezDecomp` transpose and halo subroutines in `api_cans` include options to pass `input_halo_extents, output_halo_extents, input_padding, output_padding` at runtime.
       * The values passed in `api_cans` follow similar conventions as cuDecomp, with only one difference:
          * The padding and halo `(0:2)` is assumed to follow the local array order (e.g. `yzx`), instead of the global coordinate system (`xyz`). 
          * This is purely a convention change, and does not have any further effects.
    * Thanks to this, the same transpose object (`tr`) can be used to work with `P_normal`, `P_periodic` or `P_fft`.

* Similarly, the `api_generic` transpose and halo subroutines also include options to pass custom offsets for the target array at runtime ( `P_normal`, `P_periodic` or `P_fft`).

* Additional notes:
     * In all cases and APIs (`cans` or `generic`), it is possible to define **independent** offsets for:
          * Input and output arrays.
          * Offsets `(x/y/z)` at the beginning and end of each array.
          * Different values per MPI task.
     * `diezDecomp` will automatically recognize all these customized options, and make changes at runtime.
          * Ther pre-processing overhead is negligible when adding offsets.
              * Technically, the `diezDecomp` initialization subroutines stored default offset values, but only used them at runtime.
              * Therefore, the only change made in this PR is to momentarily overwrite the default offsets stored, and then restore back the original values.
